### PR TITLE
Update to PHP 7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
+FROM php:7.1-cli
+
 FROM codeception/codeception
 
 MAINTAINER Kentaro Ohkouchi <nanasess@fsm.ne.jp>
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client mysql-client libicu-dev \
+        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libxml2-dev mysql-client libicu-dev \
         && docker-php-ext-configure \
         gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
         && docker-php-ext-install -j$(nproc) \
-        mbstring zip gd xml pdo pdo_pgsql pdo_mysql soap mcrypt intl \
+        zip gd xml pdo pdo_mysql soap intl \
         && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
Hello,

I've noticed that since Doctrine has required 7.1 to work, this codeception image no longer works for me. I therefore made this pull request which add PHP 7.1 support and removes all extensions that broke the build process.

I hope this helps.